### PR TITLE
remove state from BookshelfChanger (closes issue #9)  - sh_udacityReview_fixes

### DIFF
--- a/src/BookshelfChanger.js
+++ b/src/BookshelfChanger.js
@@ -10,10 +10,6 @@ class BookshelfChanger extends Component {
     onChangeBookshelf: PropTypes.func.isRequired
   }
 
-  state = {
-    shelf: this.props.book.shelf
-  }
-
   changeShelf(newShelf){
 
     // turns <select> into a modal component:
@@ -27,7 +23,7 @@ render() {
       <div className="book-shelf-changer">
 
         <select
-          value={this.state.shelf}
+          value={this.props.book.shelf}
           onChange={(e) => this.props.onChangeBookshelf(
             this.props.book, e.target.value)
         }>

--- a/src/BookshelfChanger.js
+++ b/src/BookshelfChanger.js
@@ -1,49 +1,42 @@
 /*jshint esnext: true */
-import React, { Component } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 
-class BookshelfChanger extends Component {
+const BookshelfChanger = function(props) {
 
-  static propTypes = {
-    book: PropTypes.object.isRequired,
-    bookshelves: PropTypes.array.isRequired,
-    onChangeBookshelf: PropTypes.func.isRequired
-  }
-
-  changeShelf(newShelf){
-
+  const changeShelf = function(newShelf){
     // turns <select> into a modal component:
     // TODO: not needed since this component closes upon <select>ion
-    this.props.onChangeBookshelf(this.prop.book, newShelf);
+    props.onChangeBookshelf(props.book, newShelf);
   }
 
-render() {
-    return (
+  return (
+    <div className="book-shelf-changer">
+      <select
+        value={props.book.shelf}
+        onChange={(e) => props.onChangeBookshelf(
+          props.book, e.target.value)
+      }>
+        <option value="none" disabled>Move to...</option>
 
-      <div className="book-shelf-changer">
+        {/* bookshelves are the options */}
+        {props.bookshelves.map( (bookshelf) => (
+          <option key={bookshelf.shelf} value={bookshelf.shelf}>
+            {bookshelf.shelfTitle}
+          </option>))}
 
-        <select
-          value={this.props.book.shelf}
-          onChange={(e) => this.props.onChangeBookshelf(
-            this.props.book, e.target.value)
-        }>
-          <option value="none" disabled>Move to...</option>
+        {/* none option removes book from bookshelf */}
+        <option value="none">None</option>
+      </select>
+    </div>
+  );
 
-          {/* bookshelves are the options */}
-          {this.props.bookshelves.map( (bookshelf) => (
-            <option key={bookshelf.shelf} value={bookshelf.shelf}>
-              {bookshelf.shelfTitle}
-            </option>))}
+}
 
-          {/* none option removes book from bookshelf */}
-          <option value="none">None</option>
-
-        </select>
-      </div>
-
-    );
-  }
-
+BookshelfChanger.propTypes = {
+  book: PropTypes.object.isRequired,
+  bookshelves: PropTypes.array.isRequired,
+  onChangeBookshelf: PropTypes.func.isRequired
 }
 
 export default BookshelfChanger;

--- a/src/BookshelfChanger.js
+++ b/src/BookshelfChanger.js
@@ -3,13 +3,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const BookshelfChanger = function(props) {
-
-  const changeShelf = function(newShelf){
-    // turns <select> into a modal component:
-    // TODO: not needed since this component closes upon <select>ion
-    props.onChangeBookshelf(props.book, newShelf);
-  }
-
   return (
     <div className="book-shelf-changer">
       <select
@@ -25,12 +18,11 @@ const BookshelfChanger = function(props) {
             {bookshelf.shelfTitle}
           </option>))}
 
-        {/* none option removes book from bookshelf */}
+        {/* none option removes book from bookshelf and deletes it from DB */}
         <option value="none">None</option>
       </select>
     </div>
   );
-
 }
 
 BookshelfChanger.propTypes = {


### PR DESCRIPTION
- As pointed out by Udacity Reviewer, state wasn't needed.
Indeed, it was simply a duplicate of one of the vars in props!  Useless, dead weight.
So I removed state.   
- With state gone, there was no need for a class component, so refactored it into a 
  functional stateless component.  
- Finally, BookshelfChanger is really a type of "modal" window.   
It closes as soon as an <select> <option> is chosen.   
- So there was no need for <select> to be a controlled input.  There was no UI to update (within the component) that depended on the option selected.  This had been noted in a TODO.
Went ahead an "refactored" to remove this code.  It was never called anyway. 

Closes issue #9 